### PR TITLE
Fix PPO policy construction with explicit device

### DIFF
--- a/learning/ppo.py
+++ b/learning/ppo.py
@@ -317,12 +317,23 @@ class OnPolicyAlgorithm(BaseAlgorithm):
 
         # Setup policy
         if self._init_setup_policy:
+            # Explicitly pass the algorithm's device to the policy constructor.
+            #
+            # Stable-Baselines3 expects a valid ``torch.device`` when building
+            # the policy networks.  The previous implementation omitted the
+            # ``device`` argument, leaving it as ``None`` inside the policy.
+            # With recent versions of PyTorch this results in layers being
+            # initialised with ``device=None`` and ``dtype=None`` which raises a
+            # ``TypeError`` during network construction (``torch.empty`` cannot
+            # handle ``None`` values).  Forwarding the device ensures the policy
+            # is properly initialised on CPU or GPU.
             self.policy = self.policy_class(
                 self.observation_space,
                 self.action_space,
                 self.lr_schedule,
+                device=self.device,
                 use_sde=self.use_sde,
-                **self.policy_kwargs
+                **self.policy_kwargs,
             )
 
             # Add Tanh activation if specified


### PR DESCRIPTION
## Summary
- pass algorithm device to PPO policy constructor to avoid torch initialization errors

## Testing
- `pytest`
- `python -m learning.train --phase 1 --seed 0 --trial 1` *(fails: ImportError: cannot import name 'Vec3' from 'py3dmath')*

------
https://chatgpt.com/codex/tasks/task_e_68a5d8c594f08323b3fc5b7dea1b677a